### PR TITLE
Fix duplicate images on second import

### DIFF
--- a/wagtailimporter/management/commands/import_pages.py
+++ b/wagtailimporter/management/commands/import_pages.py
@@ -59,7 +59,7 @@ class Command(BaseCommand):
         """Import a snippet (which is a GetForeignObject)."""
 
         obj = data.__to_value__()
-        print("Importing snippet %s" % obj)
+        print("Importing %s %s" % (obj._meta.verbose_name, obj))
         obj.save()
 
     @transaction.atomic


### PR DESCRIPTION
Existing images were not being found correctly on a second import, resulting in duplicate images being created. The image lookup has been fixed to existing images are found. The image importer also inherits from GetOrCreateForeignObject now, removing some duplicated code and allowing images to be imported like any other importable model.