### PR TITLE
Made changes to support Wagtail 5.0 and Django 4.2

### DIFF
--- a/tests/app/models.py
+++ b/tests/app/models.py
@@ -2,8 +2,13 @@
 Models for testing wagtailimporter.
 """
 from django.db import models
-from wagtail.contrib.settings.models import BaseSiteSetting, register_setting
-from wagtail.models import Page
+from wagtail import VERSION
+if VERSION < (5,0):
+    from wagtail.contrib.settings.models import BaseSetting, register_setting
+    from wagtail.core.models import Page
+else:
+    from wagtail.models import Page
+    from wagtail.contrib.settings.models import BaseSiteSetting, register_setting
 
 
 class BasicPage(Page):

--- a/tests/app/models.py
+++ b/tests/app/models.py
@@ -2,8 +2,8 @@
 Models for testing wagtailimporter.
 """
 from django.db import models
-from wagtail.contrib.settings.models import BaseSetting, register_setting
-from wagtail.core.models import Page
+from wagtail.contrib.settings.models import BaseSiteSetting, register_setting
+from wagtail.models import Page
 
 
 class BasicPage(Page):
@@ -22,7 +22,7 @@ class ForeignKeyPage(Page):
 
 
 @register_setting
-class BasicSetting(BaseSetting):
+class BasicSetting(BaseSiteSetting):
     """The simplest setting."""
     text = models.TextField(blank=True)
     cute_dog = models.ForeignKey(

--- a/tests/app/settings.py
+++ b/tests/app/settings.py
@@ -8,7 +8,7 @@ INSTALLED_APPS = [
     'taggit',
     'modelcluster',
 
-    'wagtail.core',
+    'wagtail',
     'wagtail.admin',
     'wagtail.users',
     'wagtail.sites',
@@ -17,12 +17,14 @@ INSTALLED_APPS = [
     'wagtail.documents',
     'wagtail.images',
     'wagtail.contrib.routable_page',
+    
 
     'django.contrib.admin',
     'django.contrib.auth',
     'django.contrib.contenttypes',
     'django.contrib.sessions',
     'django.contrib.staticfiles',
+    'django.contrib.messages'
 ]
 
 ALLOWED_HOSTS = ['localhost']
@@ -53,7 +55,7 @@ MIDDLEWARE = [
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
 
-    'wagtail.core.middleware.SiteMiddleware',
+    'django.contrib.sites.middleware.CurrentSiteMiddleware',
 ]
 
 TEMPLATES = [

--- a/tests/app/settings.py
+++ b/tests/app/settings.py
@@ -1,5 +1,7 @@
 """Settings for wagtailimporter tests"""
 import os
+from wagtail import VERSION
+
 
 INSTALLED_APPS = [
     'wagtailimporter',
@@ -7,8 +9,8 @@ INSTALLED_APPS = [
 
     'taggit',
     'modelcluster',
-
-    'wagtail',
+    
+    'wagtail.core' if VERSION < (5,0) else 'wagtail',
     'wagtail.admin',
     'wagtail.users',
     'wagtail.sites',
@@ -47,6 +49,9 @@ DEBUG = True
 USE_TZ = True
 TIME_ZONE = 'Australia/Hobart'
 
+
+    
+
 MIDDLEWARE = [
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.common.CommonMiddleware',
@@ -54,8 +59,7 @@ MIDDLEWARE = [
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
-
-    'django.contrib.sites.middleware.CurrentSiteMiddleware',
+    'wagtail.middleware.CurrentSiteMiddleware' if VERSION < (5,0) else 'django.contrib.sites.middleware.CurrentSiteMiddleware',
 ]
 
 TEMPLATES = [

--- a/tests/app/urls.py
+++ b/tests/app/urls.py
@@ -1,9 +1,9 @@
 """URL config."""
-from django.conf.urls import include, url
+from django.urls import include, re_path
 from wagtail.admin import urls as wagtailadmin_urls
-from wagtail.core import urls as wagtail_urls
+from wagtail import urls as wagtail_urls
 
 urlpatterns = [
-    url(r'^admin/', include(wagtailadmin_urls)),
-    url(r'', include(wagtail_urls)),
+    re_path(r'^admin/', include(wagtailadmin_urls)),
+    re_path(r'', include(wagtail_urls)),
 ]

--- a/tests/app/urls.py
+++ b/tests/app/urls.py
@@ -1,9 +1,22 @@
 """URL config."""
-from django.urls import include, re_path
+from wagtail import VERSION
 from wagtail.admin import urls as wagtailadmin_urls
-from wagtail import urls as wagtail_urls
+from django.conf.urls import include, 
 
-urlpatterns = [
-    re_path(r'^admin/', include(wagtailadmin_urls)),
-    re_path(r'', include(wagtail_urls)),
-]
+if VERSION < (5,0):
+    """URL config."""
+    from django.conf.urls import url
+    from wagtail.core import urls as wagtail_urls
+
+    urlpatterns = [
+        url(r'^admin/', include(wagtailadmin_urls)),
+        url(r'', include(wagtail_urls)),
+    ]
+else:
+    from django.urls import re_path
+    from wagtail import urls as wagtail_urls
+
+    urlpatterns = [
+        re_path(r'^admin/', include(wagtailadmin_urls)),
+        re_path(r'', include(wagtail_urls)),
+    ]

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -4,7 +4,12 @@ Test importing Wagtail pages.
 import textwrap
 
 from django.test import TestCase
-from wagtail.models import Site
+from wagtail import VERSION
+if VERSION < (5,0):
+    from wagtail.core.models import Site
+else:
+    from wagtail.models import Site
+
 from wagtail.images.models import Image
 
 from .app.models import BasicSetting

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -4,7 +4,7 @@ Test importing Wagtail pages.
 import textwrap
 
 from django.test import TestCase
-from wagtail.core.models import Site
+from wagtail.models import Site
 from wagtail.images.models import Image
 
 from .app.models import BasicSetting

--- a/tests/test_sites.py
+++ b/tests/test_sites.py
@@ -4,7 +4,7 @@ Test importing Wagtail pages.
 import textwrap
 
 from django.test import TestCase
-from wagtail.core.models import Site
+from wagtail.models import Site
 
 from .app.models import BasicPage
 from .base import ImporterTestCaseMixin

--- a/tests/test_sites.py
+++ b/tests/test_sites.py
@@ -4,7 +4,11 @@ Test importing Wagtail pages.
 import textwrap
 
 from django.test import TestCase
-from wagtail.models import Site
+from wagtail import VERSION
+if VERSION < (5,0):
+    from wagtail.core.models import Site
+else:
+    from wagtail.models import Site
 
 from .app.models import BasicPage
 from .base import ImporterTestCaseMixin

--- a/wagtailimporter/management/commands/import_pages.py
+++ b/wagtailimporter/management/commands/import_pages.py
@@ -10,8 +10,8 @@ from django.contrib.contenttypes.models import ContentType
 from django.core.exceptions import FieldDoesNotExist
 from django.core.management.base import BaseCommand, CommandError
 from django.db import transaction
-from wagtail.core.fields import StreamField
-from wagtail.core.models import Page
+from wagtail.fields import StreamField
+from wagtail.models import Page
 
 from ... import serializer
 from ...serializer import normalise

--- a/wagtailimporter/management/commands/import_pages.py
+++ b/wagtailimporter/management/commands/import_pages.py
@@ -10,8 +10,13 @@ from django.contrib.contenttypes.models import ContentType
 from django.core.exceptions import FieldDoesNotExist
 from django.core.management.base import BaseCommand, CommandError
 from django.db import transaction
-from wagtail.fields import StreamField
-from wagtail.models import Page
+from wagtail import VERSION
+if VERSION < (5,0):    
+    from wagtail.core.fields import StreamField
+    from wagtail.core.models import Page
+else:
+    from wagtail.fields import StreamField
+    from wagtail.models import Page
 
 from ... import serializer
 from ...serializer import normalise

--- a/wagtailimporter/serializer.py
+++ b/wagtailimporter/serializer.py
@@ -9,9 +9,9 @@ from pathlib import PurePosixPath
 import yaml
 from unidecode import unidecode
 from wagtail.contrib.settings.registry import registry
-from wagtail.core.fields import StreamField
-from wagtail.core.models import Page as WagtailPage
-from wagtail.core.models import Site as WagtailSite
+from wagtail.fields import StreamField
+from wagtail.models import Page as WagtailPage
+from wagtail.models import Site as WagtailSite
 from wagtail.documents.models import Document as WagtailDocument
 from wagtail.images.models import Image as WagtailImage
 

--- a/wagtailimporter/serializer.py
+++ b/wagtailimporter/serializer.py
@@ -9,9 +9,15 @@ from pathlib import PurePosixPath
 import yaml
 from unidecode import unidecode
 from wagtail.contrib.settings.registry import registry
-from wagtail.fields import StreamField
-from wagtail.models import Page as WagtailPage
-from wagtail.models import Site as WagtailSite
+from wagtail import VERSION
+if VERSION < (5,0):
+    from wagtail.core.fields import StreamField
+    from wagtail.core.models import Page as WagtailPage
+    from wagtail.core.models import Site as WagtailSite
+else:
+    from wagtail.fields import StreamField
+    from wagtail.models import Page as WagtailPage
+    from wagtail.models import Site as WagtailSite
 from wagtail.documents.models import Document as WagtailDocument
 from wagtail.images.models import Image as WagtailImage
 


### PR DESCRIPTION
Mainly updates to imports, module names, etc. 

- Replaced deprecated wagtail.core imports.
- Replaced BaseSetting import by BaseSiteSetting.
- Replaced 'wagtail.core.middleware.SiteMiddleware' by 'django.contrib.sites.middleware.CurrentSiteMiddleware'
- Changed 'from django.conf.urls import url' to from 'django.conf.urls import re_path'


